### PR TITLE
rotate db pool connections before they go stale

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ type DatabaseConfig struct {
 	MaxOpenConns    int
 	MaxIdleConns    int
 	ConnMaxIdleTime time.Duration
+	ConnMaxLifetime time.Duration
 }
 
 type CORS struct {

--- a/database/bun/database.go
+++ b/database/bun/database.go
@@ -42,6 +42,7 @@ func WrapWithBun(conf config.Config, slqDB *sql.DB) *bun.DB {
 	bunDB.SetMaxOpenConns(conf.Database.MaxOpenConns)
 	bunDB.SetMaxIdleConns(conf.Database.MaxIdleConns)
 	bunDB.SetConnMaxIdleTime(conf.Database.ConnMaxIdleTime)
+	bunDB.SetConnMaxLifetime(conf.Database.ConnMaxLifetime)
 
 	// Add query logger
 	bunDB.AddQueryHook(&BunLogger{})

--- a/database/gorm/database_gorm.go
+++ b/database/gorm/database_gorm.go
@@ -240,6 +240,14 @@ func MustOpenGORM(conf config.Config, dbName string, lf log.LoggerFactory) *gorm
 		dsn = strings.ReplaceAll(dsn, "'"+dbConf.Pass+"'", "*")
 		panic(errors.NewUnknownf("could not connect to DB: %s, error: %w", dsn, err))
 	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		panic(errors.NewUnknownf("failed to access sql db for %s: %w", dbName, err))
+	}
+	sqlDB.SetMaxOpenConns(dbConf.MaxOpenConns)
+	sqlDB.SetMaxIdleConns(dbConf.MaxIdleConns)
+	sqlDB.SetConnMaxIdleTime(dbConf.ConnMaxIdleTime)
+	sqlDB.SetConnMaxLifetime(dbConf.ConnMaxLifetime)
 	lf.GetLogger().Infof("DB connection established: \"%s\"", dbName)
 	return db
 }


### PR DESCRIPTION
## Summary
- add conn max lifetime to the shared database config
- apply pool lifetime settings to bun and gorm connections
- reduce stale pooled connections after laptop sleep or long idle periods

## Testing
- verified via dream-studio backend worker tests exercising reconnect behavior
