### PR TITLE
codex: redact request secrets and recover worker lock loss

### DIFF
--- a/rest/middleware/request_logger.go
+++ b/rest/middleware/request_logger.go
@@ -27,6 +27,22 @@ type RequestLoggerMiddleware struct {
 	excludeMap map[string]bool
 }
 
+const redactedQueryValue = "[REDACTED]"
+
+var sensitiveQueryParameters = map[string]bool{
+	"access_token":  true,
+	"api_key":       true,
+	"apikey":        true,
+	"id_token":      true,
+	"passwd":        true,
+	"password":      true,
+	"refresh_token": true,
+	"secret":        true,
+	"sig":           true,
+	"signature":     true,
+	"token":         true,
+}
+
 func NewRequestLogger(conf config.Config, lf log.LoggerFactory) *RequestLoggerMiddleware {
 	excludes := conf.HttpServer.ReqLoggerExcludes
 	excludeMap := make(map[string]bool, len(excludes))
@@ -85,6 +101,38 @@ func (rw *responseWriter) Unwrap() http.ResponseWriter {
 	return rw.ResponseWriter
 }
 
+func redactURLQuery(original *url.URL) (*url.URL, url.Values) {
+	query := original.Query()
+	didRedact := false
+	for key, values := range query {
+		if !sensitiveQueryParameters[strings.ToLower(key)] {
+			continue
+		}
+		didRedact = true
+		for i := range values {
+			values[i] = redactedQueryValue
+		}
+	}
+	if !didRedact {
+		return original, query
+	}
+	redacted := *original
+	redacted.RawQuery = query.Encode()
+	return &redacted, query
+}
+
+func redactURLString(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "[INVALID URL]"
+	}
+	redacted, _ := redactURLQuery(parsed)
+	if redacted == parsed {
+		return rawURL
+	}
+	return redacted.String()
+}
+
 func (m *RequestLoggerMiddleware) Handle(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
@@ -121,19 +169,21 @@ func (m *RequestLoggerMiddleware) Handle(next http.Handler) http.Handler {
 			}
 		}
 
+		_, redactedQuery := redactURLQuery(r.URL)
+
 		attrs := []slog.Attr{
 			slog.GroupAttrs("http",
 				slog.String("method", r.Method),
-				slog.String("url", r.RequestURI),
+				slog.String("url", redactURLString(r.RequestURI)),
 				slog.String("request_id", requestID),
-				slog.String("referer", r.Referer()),
+				slog.String("referer", redactURLString(r.Referer())),
 				slog.String("useragent", r.UserAgent()),
 				slog.String("version", r.Proto),
 				slog.GroupAttrs("url_details",
 					slog.String("host", hostname),
 					portAttr,
 					slog.String("path", urlPath),
-					slog.Any("queryString", r.URL.Query()),
+					slog.Any("queryString", redactedQuery),
 				),
 			),
 			slog.String("network.client.ip", clientIP),

--- a/rest/middleware/request_logger_test.go
+++ b/rest/middleware/request_logger_test.go
@@ -1,8 +1,11 @@
 package middleware_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -43,4 +46,50 @@ func TestRequestLoggerMiddleware_ResponseWriterGuard(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rec2.Code)
 	require.Equal(t, "hello world", rec2.Body.String())
+}
+
+func TestRequestLoggerMiddleware_RedactsSensitiveQueryParameters(t *testing.T) {
+	var output bytes.Buffer
+	conf := config.Config{}
+	lf := log.NewLoggerFactoryWithWriter(config.RootConfig{
+		Log: config.LogConfig{Level: config.LogLevelInfo, Structured: true},
+	}, &output)
+	mw := middleware.NewRequestLogger(conf, lf)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "request-secret", r.URL.Query().Get("token"))
+		require.Equal(t, "case-secret", r.URL.Query().Get("TOKEN"))
+		require.Equal(t, "visible", r.URL.Query().Get("safe"))
+		w.WriteHeader(http.StatusOK)
+	})
+	req := httptest.NewRequest(http.MethodGet, "/upload?token=request-secret&TOKEN=case-secret&access_token=access-secret&safe=visible", nil)
+	req.Header.Set("Referer", "https://example.com/editor?token=referer-secret&view=graph")
+	req = req.WithContext(lf.AddToCtx(req.Context()))
+	mw.Handle(handler).ServeHTTP(httptest.NewRecorder(), req)
+
+	logs := output.String()
+	for _, secret := range []string{"request-secret", "case-secret", "access-secret", "referer-secret"} {
+		require.NotContains(t, logs, secret)
+	}
+
+	var requestLog map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(logs), "\n") {
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &entry))
+		if entry["msg"] == "Req End: /upload" {
+			requestLog = entry
+		}
+	}
+	require.NotNil(t, requestLog)
+
+	httpAttrs := requestLog["http"].(map[string]any)
+	require.Equal(t, "/upload?TOKEN=%5BREDACTED%5D&access_token=%5BREDACTED%5D&safe=visible&token=%5BREDACTED%5D", httpAttrs["url"])
+	require.Equal(t, "https://example.com/editor?token=%5BREDACTED%5D&view=graph", httpAttrs["referer"])
+
+	urlDetails := httpAttrs["url_details"].(map[string]any)
+	query := urlDetails["queryString"].(map[string]any)
+	require.Equal(t, []any{"[REDACTED]"}, query["token"])
+	require.Equal(t, []any{"[REDACTED]"}, query["TOKEN"])
+	require.Equal(t, []any{"[REDACTED]"}, query["access_token"])
+	require.Equal(t, []any{"visible"}, query["safe"])
 }

--- a/worker/context_cause_internal_test.go
+++ b/worker/context_cause_internal_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testing"
 	"time"
@@ -50,8 +51,9 @@ func (l *lockLossLock) AutoExtend(ctx context.Context) (context.Context, error) 
 }
 
 type cancellationCauseWorker struct {
-	runs     int
-	finalErr error
+	runs           int
+	interruptedErr error
+	finalErr       error
 }
 
 func (w *cancellationCauseWorker) GetName() string { return "cancellation-cause-worker" }
@@ -64,6 +66,9 @@ func (w *cancellationCauseWorker) Run(ctx context.Context) error {
 	w.runs++
 	if w.runs == 1 {
 		<-ctx.Done()
+		if w.interruptedErr != nil {
+			return w.interruptedErr
+		}
 		return ctx.Err()
 	}
 	return w.finalErr
@@ -74,6 +79,19 @@ func TestSingleWorkerRunnerPreservesLockLossCancellationCause(t *testing.T) {
 	finalErr := errors.New("stop after lock reacquisition")
 	factory := &lockLossFactory{cause: lockLossErr}
 	probe := &cancellationCauseWorker{finalErr: finalErr}
+	h := &LongRunningWorkerHandler{ctx: context.Background(), dlFactory: factory}
+
+	err := h.singleWorkerRunner(NewWorkerContext(context.Background(), probe.GetName(), probe.GetID()), probe)
+
+	require.ErrorIs(t, err, finalErr)
+	require.Equal(t, 2, probe.runs)
+}
+
+func TestSingleWorkerRunnerPreservesLockLossCauseWhenDependencyMasksCancellation(t *testing.T) {
+	lockLossErr := fwerrors.Newf(distributedlock.ErrCodeLockNotAutoExtended, "lock lease expired")
+	finalErr := errors.New("stop after lock reacquisition")
+	factory := &lockLossFactory{cause: lockLossErr}
+	probe := &cancellationCauseWorker{interruptedErr: sql.ErrTxDone, finalErr: finalErr}
 	h := &LongRunningWorkerHandler{ctx: context.Background(), dlFactory: factory}
 
 	err := h.singleWorkerRunner(NewWorkerContext(context.Background(), probe.GetName(), probe.GetID()), probe)

--- a/worker/context_cause_internal_test.go
+++ b/worker/context_cause_internal_test.go
@@ -1,0 +1,83 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/southernlabs-io/go-fw/distributedlock"
+	fwerrors "github.com/southernlabs-io/go-fw/errors"
+)
+
+type lockLossFactory struct {
+	cause           error
+	autoExtendCalls int
+}
+
+func (f *lockLossFactory) NewDistributedLock(resource string, ttl time.Duration) distributedlock.DistributedLock {
+	return &lockLossLock{factory: f, resource: resource, ttl: ttl}
+}
+
+type lockLossLock struct {
+	factory  *lockLossFactory
+	resource string
+	ttl      time.Duration
+	cancel   context.CancelCauseFunc
+}
+
+func (l *lockLossLock) Resource() string                      { return l.resource }
+func (l *lockLossLock) TTL() time.Duration                    { return l.ttl }
+func (l *lockLossLock) Expiration() time.Time                 { return time.Now().Add(l.ttl) }
+func (l *lockLossLock) ExtendedCount() int                    { return 0 }
+func (l *lockLossLock) Lock(context.Context) error            { return nil }
+func (l *lockLossLock) TryLock(context.Context) (bool, error) { return true, nil }
+func (l *lockLossLock) Unlock(context.Context) error {
+	l.cancel(context.Canceled)
+	return nil
+}
+func (l *lockLossLock) Extend(context.Context) (bool, error) { return true, nil }
+func (l *lockLossLock) AutoExtend(ctx context.Context) (context.Context, error) {
+	ctx, cancel := context.WithCancelCause(ctx)
+	l.cancel = cancel
+	l.factory.autoExtendCalls++
+	if l.factory.autoExtendCalls == 1 {
+		cancel(l.factory.cause)
+	}
+	return ctx, nil
+}
+
+type cancellationCauseWorker struct {
+	runs     int
+	finalErr error
+}
+
+func (w *cancellationCauseWorker) GetName() string { return "cancellation-cause-worker" }
+func (w *cancellationCauseWorker) GetID() string   { return "test" }
+func (w *cancellationCauseWorker) GetConcurrency() ConcurrencyConfig {
+	return ConcurrencyConfig{Mode: ConcurrencyModeSingle, SingleLockTTL: time.Second}
+}
+func (w *cancellationCauseWorker) GetRetry() RetryConfig { return RetryConfig{} }
+func (w *cancellationCauseWorker) Run(ctx context.Context) error {
+	w.runs++
+	if w.runs == 1 {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return w.finalErr
+}
+
+func TestSingleWorkerRunnerPreservesLockLossCancellationCause(t *testing.T) {
+	lockLossErr := fwerrors.Newf(distributedlock.ErrCodeLockNotAutoExtended, "lock lease expired")
+	finalErr := errors.New("stop after lock reacquisition")
+	factory := &lockLossFactory{cause: lockLossErr}
+	probe := &cancellationCauseWorker{finalErr: finalErr}
+	h := &LongRunningWorkerHandler{ctx: context.Background(), dlFactory: factory}
+
+	err := h.singleWorkerRunner(NewWorkerContext(context.Background(), probe.GetName(), probe.GetID()), probe)
+
+	require.ErrorIs(t, err, finalErr)
+	require.Equal(t, 2, probe.runs)
+}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -287,8 +287,9 @@ func (h *LongRunningWorkerHandler) singleWorkerRunner(ctx context.Context, worke
 			))
 			log.GetLoggerFromCtx(wCtx).Infof("Running worker: %s, with concurrency: %+v", worker.GetName(), worker.GetConcurrency())
 			err = worker.Run(wCtx)
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				// Dependencies commonly return ctx.Err(), which drops the lease-loss cancellation cause.
+			if wCtx.Err() != nil {
+				// The runner owns wCtx, so its lifecycle cause takes precedence over errors
+				// returned by dependencies while cancellation is unwinding.
 				if cause := context.Cause(wCtx); cause != nil {
 					return cause
 				}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -286,7 +286,14 @@ func (h *LongRunningWorkerHandler) singleWorkerRunner(ctx context.Context, worke
 				slog.String("run_id", newRunID()),
 			))
 			log.GetLoggerFromCtx(wCtx).Infof("Running worker: %s, with concurrency: %+v", worker.GetName(), worker.GetConcurrency())
-			return worker.Run(wCtx)
+			err = worker.Run(wCtx)
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				// Dependencies commonly return ctx.Err(), which drops the lease-loss cancellation cause.
+				if cause := context.Cause(wCtx); cause != nil {
+					return cause
+				}
+			}
+			return err
 		}()
 		runExecTime = time.Since(t0).Milliseconds()
 		if runExecTime > retryCountResetMillis {


### PR DESCRIPTION
## Why

A local DreamStudio backend outage exposed two framework problems in the same diagnostic log:

- Request logging emitted signed upload tokens in both http.url and http.url_details.queryString, with the same potential leak through referrers.
- When a single-worker distributed-lock lease was lost, the auto-extension context carried the recoverable lifecycle cause, but downstream cancellation unwinding could return plain context canceled or a secondary sql.ErrTxDone. The worker runner classified that masked result as fatal and shut down the Fx application instead of releasing and reacquiring the lease.

The lock is still needed to ensure only one process runs each ConcurrencyModeSingle worker when multiple backend instances share the database. The bug was in preserving the runner-owned lifecycle cause, not in taking the lease.

## What changed

- Redact token, password, API-key, secret, and signature query parameters from logged request URLs, parsed query fields, and referrers without modifying the request passed to handlers.
- At the single-worker runner boundary, prefer context.Cause whenever the runner-owned context has been canceled. This preserves typed lease-loss and shutdown causes even when dependencies return a secondary error while cancellation unwinds, while still failing loudly for errors returned from a live worker context.
- Add regressions covering request redaction, lock reacquisition after plain cancellation, and the exact sql.ErrTxDone masking case seen after sleep.

## Validation

- go test ./rest/middleware ./worker -count=1
- go vet ./rest/middleware ./worker
- go test -short ./internal/domain/event ./internal/domain/fs ./internal/domain/skillexec in the DreamStudio backend
- Live make run-local-fancy outage test: paused local Postgres until 10-second TCP timeouts forced workers to lose their leases, restored Postgres, and confirmed the original backend process remained alive while workers reacquired leases and re-subscribed
- git diff --check origin/feature/std-http-server...HEAD

The repository-wide short suite exercised 370 tests but is not fully green because the unrelated database/bun TestWithLane_WithValidDB test uses MockIDB where WithLane now requires *bun.DB.